### PR TITLE
Backport to ubuntu 20.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,24 +17,20 @@ project(
 
 include(cmake/CPM.cmake)
 
-find_package(fmt 10.1)
-if(NOT TARGET fmt::fmt)
-  option(FMT_INSTALL "create an installable target" YES)
-  if(FMT_INSTALL)
-    # A git package with both version and tag provided FIXME: EXCLUDE_FROM_ALL must be OFF or fmt
-    # target will NOT be installed! CK XXX CPMAddPackage("gh:fmtlib/fmt@10.1.1#10.1.1")
+option(FMT_INSTALL "create an installable target" YES)
+# A git package with both version and tag provided FIXME: EXCLUDE_FROM_ALL must be OFF or fmt target
+# will NOT be installed! CK XXX CPMAddPackage("gh:fmtlib/fmt@10.1.1#10.1.1")
 
-    # NOTE: The fmt library has to be installed if not found! BUT either clang-tidy checks nor
-    # compiler warnings are wanted!
-    CPMAddPackage(
-      NAME fmt
-      GIT_TAG 10.1.1
-      GITHUB_REPOSITORY fmtlib/fmt
-      EXCLUDE_FROM_ALL OFF
-      SYSTEM YES # used in case of cmake v3.25
-    )
-  endif()
-endif()
+# NOTE: The fmt library has to be installed if not found! BUT either clang-tidy checks nor compiler
+# warnings are wanted!
+CPMFindPackage(
+  NAME fmt
+  GIT_TAG 10.1.1
+  VERSION 10.1
+  GITHUB_REPOSITORY fmtlib/fmt
+  EXCLUDE_FROM_ALL OFF
+  SYSTEM YES # used in case of cmake v3.25
+)
 
 if(LINUX)
   # XXX set(CMAKE_EXE_LINKER_FLAGS -static)
@@ -48,16 +44,17 @@ if(CMAKE_SKIP_INSTALL_RULES)
 endif()
 
 install(TARGETS ${PROJECT_NAME} RUNTIME COMPONENT ${PROJECT_NAME})
-if(NOT FMT_INSTALL)
-  install(IMPORTED_RUNTIME_ARTIFACTS fmt::fmt RUNTIME_DEPENDENCY_SET runtime_dependency_set RUNTIME)
-  install(RUNTIME_DEPENDENCY_SET runtime_dependency_set RUNTIME DESTINATION lib)
-endif()
+install(IMPORTED_RUNTIME_ARTIFACTS ${PROJECT_NAME} RUNTIME_DEPENDENCY_SET runtime_dependency_set
+        RUNTIME
+)
+install(RUNTIME_DEPENDENCY_SET runtime_dependency_set RUNTIME DESTINATION lib)
 
 if(LINUX)
-  # set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS "/lib/x86_64-linux-gnu/libstdc++.so.6")
+  # XXX set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS "/lib/x86_64-linux-gnu/libstdc++.so.6;...")
 endif()
+
 if(MSVC OR LINUX)
-  include(InstallRequiredSystemLibraries)
+  # XXX include(InstallRequiredSystemLibraries)
 endif()
 
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,17 +44,13 @@ if(CMAKE_SKIP_INSTALL_RULES)
 endif()
 
 install(TARGETS ${PROJECT_NAME} RUNTIME COMPONENT ${PROJECT_NAME})
-install(IMPORTED_RUNTIME_ARTIFACTS ${PROJECT_NAME} RUNTIME_DEPENDENCY_SET runtime_dependency_set
-        RUNTIME
+install(IMPORTED_RUNTIME_ARTIFACTS ${PROJECT_NAME} RUNTIME_DEPENDENCY_SET
+        _dependency_set
 )
-install(RUNTIME_DEPENDENCY_SET runtime_dependency_set RUNTIME DESTINATION lib)
-
-if(LINUX)
-  # XXX set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS "/lib/x86_64-linux-gnu/libstdc++.so.6;...")
-endif()
-
-if(MSVC OR LINUX)
-  # XXX include(InstallRequiredSystemLibraries)
-endif()
+# FIXME: CONFLICTING_DEPENDENCIES_PREFIX  _conflicts
+install(RUNTIME_DEPENDENCY_SET _dependency_set
+        POST_EXCLUDE_REGEXES "${CMAKE_INSTALL_PREFIX}/lib"
+        RUNTIME DESTINATION lib
+)
 
 include(CPack)

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,14 +27,6 @@ WORKDIR /home/app
 RUN bash -c 'source ~/.cpprc \
     # build and install the C++ example
     && cmake --workflow --preset Release --fresh \
-    # install the C++ runtime libraries
-    && mkdir -p stagedir/lib \
-    && cp -f \
-      /lib/x86_64-linux-gnu/libm.so* \
-      /lib/x86_64-linux-gnu/libc.so* \
-      /lib/x86_64-linux-gnu/libgcc_s.so* \
-      /lib/x86_64-linux-gnu/libstdc++.so* \
-    /home/app/stagedir/lib \
     && tar --exclude=cmake --exclude=pkgconfig -czvf stagedir.tar.gz stagedir/lib stagedir/bin'
 
 ENTRYPOINT ["/bin/bash"]
@@ -46,7 +38,6 @@ FROM ubuntu:20.04 as runner
 # copy the built binaries and their runtime dependencies
 COPY --from=builder /home/app/*.tar.gz /home/app/
 WORKDIR /home/app/
-# XXX COPY --from=builder /home/app/stagedir stagedir
 RUN bash -c 'tar -xzvf stagedir.tar.gz --strip-components 1'
 ENV LD_LIBRARY_PATH /home/app/lib
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN bash -c 'source ~/.cpprc \
       /lib/x86_64-linux-gnu/libgcc_s.so* \
       /lib/x86_64-linux-gnu/libstdc++.so* \
     /home/app/stagedir/lib \
-    && tar --exclude=cmake -czvf stagedir.tar.gz stagedir/lib stagedir/bin'
+    && tar --exclude=cmake --exclude=pkgconfig -czvf stagedir.tar.gz stagedir/lib stagedir/bin'
 
 ENTRYPOINT ["/bin/bash"]
 
@@ -51,7 +51,7 @@ RUN bash -c 'tar -xzvf stagedir.tar.gz --strip-components 1'
 ENV LD_LIBRARY_PATH /home/app/lib
 
 # Running (example):
-ENTRYPOINT ["bin/Hello"]
+ENTRYPOINT ["bin/Hello", "--help"]
 
-# TODO: for (docker run -ti):
+# TODO: for (docker run -it):
 # XXX ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN bash -c 'source ~/.cpprc \
       /lib/x86_64-linux-gnu/libc.so* \
       /lib/x86_64-linux-gnu/libgcc_s.so* \
       /lib/x86_64-linux-gnu/libstdc++.so* \
-    /home/app/stagedir/lib'
+    /home/app/stagedir/lib \
+    && tar --exclude=cmake -czvf stagedir.tar.gz stagedir/lib stagedir/bin'
 
 ENTRYPOINT ["/bin/bash"]
 
@@ -45,25 +46,12 @@ FROM ubuntu:20.04 as runner
 # copy the built binaries and their runtime dependencies
 COPY --from=builder /home/app/*.tar.gz /home/app/
 WORKDIR /home/app/
-COPY --from=builder /home/app/stagedir stagedir
-RUN bash -c 'tar -xzvf *.gz --strip-components 1'
-ENV LD_LIBRARY_PATH /home/app/stagedir/lib
+# XXX COPY --from=builder /home/app/stagedir stagedir
+RUN bash -c 'tar -xzvf stagedir.tar.gz --strip-components 1'
+ENV LD_LIBRARY_PATH /home/app/lib
 
 # Running (example):
 ENTRYPOINT ["bin/Hello"]
 
 # TODO: for (docker run -ti):
 # XXX ENTRYPOINT ["/bin/bash"]
-
-# root@b6fef6ed1368:/home/app# ldd bin/Hello
-# 	linux-vdso.so.1 (0x00007ffdd6fed000)
-# 	libfmt.so.10 => /home/app/stagedir/lib/libfmt.so.10 (0x00007f0084aea000)
-# 	libc.so.6 => /home/app/stagedir/lib/libc.so.6 (0x00007f00848f8000)
-# 	libstdc++.so.6 => /home/app/stagedir/lib/libstdc++.so.6 (0x00007f008468a000)
-# 	libgcc_s.so.1 => /home/app/stagedir/lib/libgcc_s.so.1 (0x00007f0084665000)
-# 	/lib64/ld-linux-x86-64.so.2 (0x00007f0084b1b000)
-# 	libm.so.6 => /home/app/stagedir/lib/libm.so.6 (0x00007f0084516000)
-# root@b6fef6ed1368:/home/app#
-# root@b6fef6ed1368:/home/app# bin/Hello
-# Hello, world!
-# root@b6fef6ed1368:/home/app#

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,19 @@
 #### Base Image
-FROM ubuntu:22.04 as setup-cpp-ubuntu
+FROM ubuntu:20.04 as setup-cpp-ubuntu
 
-RUN apt-get update -qq && \
-    # install nodejs
-    apt-get install -y --no-install-recommends git nodejs npm && \
+RUN apt-get update -qq && export DEBIAN_FRONTEND=noninteractive && \
+    apt-get install -y --no-install-recommends git wget gnupg ca-certificates && \
     # install setup-cpp
-    npm install -g setup-cpp@v0.35.4 && \
-    # install the compiler and tools
-    setup-cpp \
-        --nala true \
+    wget --quiet "https://github.com/aminya/setup-cpp/releases/download/v0.35.6/setup-cpp-x64-linux" && \
+    chmod +x setup-cpp-x64-linux && \
+    # install the minmal compiler and tools set for build
+    ./setup-cpp-x64-linux \
         --compiler gcc \
         --cmake true \
         --ninja true \
-        --python true \
-        --make true \
-        --gcovr true \
-        --doxygen true \
-        --ccache true && \
+        --python true && \
     # cleanup
-    nala autoremove -y && \
-    nala autopurge -y && \
-    apt-get clean && \
-    nala clean --lists && \
+    apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/*
 
@@ -33,9 +25,11 @@ FROM setup-cpp-ubuntu AS builder
 COPY . /home/app
 WORKDIR /home/app
 RUN bash -c 'source ~/.cpprc \
+    # build and install the C++ example
     && cmake --workflow --preset Release --fresh \
+    # install the C++ runtime libraries
     && mkdir -p stagedir/lib \
-    && cp \
+    && cp -f \
       /lib/x86_64-linux-gnu/libm.so* \
       /lib/x86_64-linux-gnu/libc.so* \
       /lib/x86_64-linux-gnu/libgcc_s.so* \
@@ -46,7 +40,7 @@ ENTRYPOINT ["/bin/bash"]
 
 #### Running environment
 # use a fresh image as the runner
-FROM ubuntu:22.04 as runner
+FROM ubuntu:20.04 as runner
 
 # copy the built binaries and their runtime dependencies
 COPY --from=builder /home/app/*.tar.gz /home/app/
@@ -61,14 +55,15 @@ ENTRYPOINT ["bin/Hello"]
 # TODO: for (docker run -ti):
 # XXX ENTRYPOINT ["/bin/bash"]
 
-# root@106b5efb0b5e:/home/app# ldd bin/Hello
-# 	linux-vdso.so.1 (0x00007ffc9d3a6000)
-# 	libfmt.so.10 => /home/app/stagedir/lib/libfmt.so.10 (0x00007f902a1f4000)
-# 	libc.so.6 => /home/app/stagedir/lib/libc.so.6 (0x00007f9029fcc000)
-# 	libstdc++.so.6 => /home/app/stagedir/lib/libstdc++.so.6 (0x00007f9029d5f000)
-# 	libgcc_s.so.1 => /home/app/stagedir/lib/libgcc_s.so.1 (0x00007f9029d3b000)
-# 	/lib64/ld-linux-x86-64.so.2 (0x00007f902a225000)
-# 	libm.so.6 => /home/app/stagedir/lib/libm.so.6 (0x00007f9029c54000)
-# root@106b5efb0b5e:/home/app# bin/Hello
+# root@b6fef6ed1368:/home/app# ldd bin/Hello
+# 	linux-vdso.so.1 (0x00007ffdd6fed000)
+# 	libfmt.so.10 => /home/app/stagedir/lib/libfmt.so.10 (0x00007f0084aea000)
+# 	libc.so.6 => /home/app/stagedir/lib/libc.so.6 (0x00007f00848f8000)
+# 	libstdc++.so.6 => /home/app/stagedir/lib/libstdc++.so.6 (0x00007f008468a000)
+# 	libgcc_s.so.1 => /home/app/stagedir/lib/libgcc_s.so.1 (0x00007f0084665000)
+# 	/lib64/ld-linux-x86-64.so.2 (0x00007f0084b1b000)
+# 	libm.so.6 => /home/app/stagedir/lib/libm.so.6 (0x00007f0084516000)
+# root@b6fef6ed1368:/home/app#
+# root@b6fef6ed1368:/home/app# bin/Hello
 # Hello, world!
-# root@106b5efb0b5e:/home/app#
+# root@b6fef6ed1368:/home/app#

--- a/docker.md
+++ b/docker.md
@@ -6,12 +6,20 @@ in your terminal:
 ```bash
 docker build -f ./Dockerfile --tag=devcontainer:latest .
 docker run -it --rm devcontainer:latest
+docker create --name Hello devcontainer:latest
+docker cp Hello:/home/app/stagedir.tar.gz Hello-ubuntu-v20.04.tgz
+docker rm -f Hello
 ```
 
-This command will put you in a `bash` session in a Ubuntu 22.04 Docker container,
+If may activate as `ENTRYPOINT ["/bin/bash"]` in Dockerfile and build it again.
+
+```bash
+docker run -it --rm devcontainer:latest
+```
+
+This command may put you in a `bash` session in a Ubuntu 20.04 Docker container,
 with all of the build tools already installed.
-Additionally, you will have `g++-13` and `clang++-16` installed as the default
-versions of `g++` and `clang++`.
+Additionally, you will have `g++-11` installed as the default versions of `g++` .
 
 You will be logged in as root, so you will see the `#` symbol as your prompt.
 You will be in a directory that contains a copy of the `project`;


### PR DESCRIPTION
**NOTE**: nodejs, nala, and govr can`t not  installed  on `ubuntu 20.04` as on `ubuntu 22.04` !

Use `wget --quiet`

`gcovr`, `ccache`, and `doxygen` not really used yet.
